### PR TITLE
Updates for python 3 and newer version of antivirus scanner

### DIFF
--- a/build-antivirus-from-source.tf
+++ b/build-antivirus-from-source.tf
@@ -5,8 +5,12 @@ resource "null_resource" "build-antivirus-from-source" {
     : 0
   )
 
+  triggers = {
+    git_revision = "${var.git-revision}"
+  }
+
   provisioner "local-exec" {
-    command = "bash ${path.module}/scripts/build-antivirus-from-source.sh"
+    command = "REVISION=${var.git-revision} bash ${path.module}/scripts/build-antivirus-from-source.sh"
   }
 }
 
@@ -14,11 +18,11 @@ resource "aws_s3_bucket_object" "antivirus-code" {
   depends_on = [null_resource.build-antivirus-from-source]
 
   bucket = aws_s3_bucket.antivirus-code.bucket
-  key    = "lambda.zip"
+  key    = "lambda-${var.git-revision}.zip"
 
   source = (
     var.antivirus-lambda-code == null
-    ? "/tmp/bucket-antivirus-function/build/lambda.zip"
+    ? "~/bucket-antivirus-function/build/lambda.zip"
     : pathexpand(var.antivirus-lambda-code)
   )
 }

--- a/scanner-function.tf
+++ b/scanner-function.tf
@@ -2,7 +2,7 @@ resource "aws_lambda_function" "antivirus-scanner" {
   function_name = "bucket-antivirus-scanner"
   timeout       = 300
   memory_size   = 1024
-  runtime       = "python2.7"
+  runtime       = "python3.7"
   handler       = "scan.lambda_handler"
   role          = aws_iam_role.antivirus-scanner-role.arn
 

--- a/scripts/build-antivirus-from-source.sh
+++ b/scripts/build-antivirus-from-source.sh
@@ -1,31 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
-GIT_DIR=/tmp/bucket-antivirus-function
-LAST_WORKING_COMMIT=90b1061
-AMZ_LINUX_VERSION=2
+GIT_DIR=~/bucket-antivirus-function
 
 rm -rf $GIT_DIR
 
 git clone https://github.com/upsidetravel/bucket-antivirus-function.git $GIT_DIR
 
 cd $GIT_DIR
-git checkout $LAST_WORKING_COMMIT
+git checkout $REVISION
 
 container_dir=/opt/app
 
 rm -rf bin/
 rm -rf build/
 
-docker run --rm -i \
-  -v $(pwd):$container_dir \
-  -w=$container_dir \
-  amazonlinux:$AMZ_LINUX_VERSION \
-  /bin/bash -c "./build_lambda.sh"
+make archive
 
-# restore current user permissions
-docker run --rm -i \
-  -v $(pwd):$container_dir \
-  -w=$container_dir \
-  amazonlinux:$AMZ_LINUX_VERSION \
-  /bin/bash -c "chown -R $(id -u ${USER}):$(id -g ${USER}) ."

--- a/scripts/build-antivirus-from-source.sh
+++ b/scripts/build-antivirus-from-source.sh
@@ -16,4 +16,3 @@ rm -rf bin/
 rm -rf build/
 
 make archive
-

--- a/update-function.tf
+++ b/update-function.tf
@@ -1,8 +1,8 @@
 resource "aws_lambda_function" "antivirus-update" {
   function_name = "bucket-antivirus-update"
   timeout       = 300
-  memory_size   = 512
-  runtime       = "python2.7"
+  memory_size   = 1024
+  runtime       = "python3.7"
   handler       = "update.lambda_handler"
   role          = aws_iam_role.antivirus-update-role.arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,9 @@ variable "antivirus-update-rate" {
   type        = string
   default     = "3 hours"
 }
+
+variable "git-revision" {
+  description = "Git revision of the lambda code to build"
+  type        = string
+  default     = "f0baa5d"
+}


### PR DESCRIPTION
So out of the box this module had a few problems.

1) For whatever reason the python2 based function just wouldn't build anymore so I updated it to python3 and everything worked as expected.

2) The path it uses for it's builds doesn't play nice with the default permissions on the mac.

3) It doesn't rebuild the source, ever. I got it updating based on the git revision of the antivirus lambda.

winterlightlabs/product-devops#115

