### PR TITLE
Increase the scan functions memory to 3008 MB

### DIFF
--- a/scanner-function.tf
+++ b/scanner-function.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function" "antivirus-scanner" {
   function_name = "${var.env}-bucket-antivirus-scanner"
   timeout       = 300
-  memory_size   = 1024
+  memory_size   = 3008
   runtime       = "python3.7"
   handler       = "scan.lambda_handler"
   role          = aws_iam_role.antivirus-scanner-role.arn


### PR DESCRIPTION
Looks like a number of errors in the lambda function are being caused by clam getting more greedy with memory recently.

Around the start of July the error rate increased from almost 0 to whole numbers, with this last week being all errors 😞 

`REPORT RequestId: 149562b0-3d7f-464f-8e7a-8527e530456a Duration: 300052.10 ms Billed Duration: 300000 ms Memory Size: 1024 MB Max Memory Used: 1025 MB Init Duration: 444.34 ms`

I've already applied this change to stop the bleeding.