### PR TITLE
Use forked codebase, increase memory on updater

### DIFF
--- a/scripts/build-antivirus-from-source.sh
+++ b/scripts/build-antivirus-from-source.sh
@@ -5,7 +5,7 @@ GIT_DIR=~/bucket-antivirus-function
 
 rm -rf $GIT_DIR
 
-git clone https://github.com/upsidetravel/bucket-antivirus-function.git $GIT_DIR
+git clone https://github.com/winterlightlabs/bucket-antivirus-function.git $GIT_DIR
 
 cd $GIT_DIR
 git checkout $REVISION

--- a/update-function.tf
+++ b/update-function.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function" "antivirus-update" {
   function_name = "${var.env}-bucket-antivirus-update"
   timeout       = 300
-  memory_size   = 1024
+  memory_size   = 4096
   runtime       = "python3.7"
   handler       = "update.lambda_handler"
   role          = aws_iam_role.antivirus-update-role.arn

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "antivirus-update-rate" {
 variable "git-revision" {
   description = "Git revision of the lambda code to build"
   type        = string
-  default     = "f0baa5d"
+  default     = "7e14840"
 }
 
 variable "scanner-sns-topics" {


### PR DESCRIPTION
Changes deployment process to use our fork https://github.com/winterlightlabs/bucket-antivirus-function

The updater was hitting the memory limit in testing, so I increased that for safety.